### PR TITLE
Complete Milestone 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Open http://localhost:8000/docs for the interactive Swagger UI.
 
 ### Milestone 2 – REST API Skeleton
 
-* [ ] Scaffold FastAPI app & `/health`
-* [ ] `/ais` endpoint returning latest row
+* [x] Scaffold FastAPI app & `/health`
+* [x] `/ais` endpoint returning latest row
 
 ### Milestone 3 – Map Rendering
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ authors = [{name = "Your Name"}]
 dependencies = [
     "websockets>=10",
     "aiosqlite>=0.21",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.23",
 ]
 
 [project.scripts]
 sailtrack-listener = "sailtrack.ais_listener:main"
+sailtrack-api = "sailtrack.api:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 websockets>=10
 aiosqlite>=0.21
+fastapi>=0.110
+uvicorn[standard]>=0.23

--- a/src/sailtrack/ais_listener.py
+++ b/src/sailtrack/ais_listener.py
@@ -4,7 +4,7 @@ import os
 import json
 import asyncio
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import websockets
 import aiosqlite
@@ -28,8 +28,8 @@ async def listen(api_key: str, mmsi: Optional[int] = None) -> None:
         await db.execute(CREATE_TABLE_SQL)
         await db.commit()
 
-        headers = {}
-        subscription = {"APIKey": api_key}
+        headers: dict[str, str] = {}
+        subscription: dict[str, Any] = {"APIKey": api_key}
         if mmsi:
             subscription["FilterMMSI"] = [str(mmsi)]
 

--- a/src/sailtrack/api.py
+++ b/src/sailtrack/api.py
@@ -1,0 +1,49 @@
+"""Minimal FastAPI application exposing AIS data."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import aiosqlite
+from fastapi import FastAPI, HTTPException
+import uvicorn
+
+DB_PATH = os.getenv("DB_PATH", "ais.db")
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.get("/ais")
+async def latest_ais() -> dict:
+    """Return the latest AIS message from the database."""
+    query = "SELECT timestamp, raw_message FROM ais_messages ORDER BY id DESC LIMIT 1"
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(query) as cursor:
+            row = await cursor.fetchone()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="No AIS messages available")
+
+    timestamp, raw_message = row
+    try:
+        message = json.loads(raw_message)
+    except json.JSONDecodeError:
+        message = {"raw": raw_message}
+
+    return {"timestamp": timestamp, "message": message}
+
+
+def main() -> None:
+    """Run the FastAPI app using uvicorn."""
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add FastAPI and uvicorn dependencies
- implement REST API with `/health` and `/ais`
- expose new CLI entry point
- type annotations cleanup for `ais_listener`
- mark Milestone 2 complete in README

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554cb78514832c96078ad328211f9a